### PR TITLE
Add Customization model to Prisma schema

### DIFF
--- a/prisma/migrations/20250604044554_init_customization/migration.sql
+++ b/prisma/migrations/20250604044554_init_customization/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `color` on the `Customization` table. All the data in the column will be lost.
+  - You are about to alter the column `design` on the `Customization` table. The data in that column could be lost. The data in that column will be cast from `String` to `Json`.
+  - Added the required column `updatedAt` to the `Customization` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Customization" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT,
+    "productType" TEXT NOT NULL,
+    "design" JSONB NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Customization" ("design", "id", "productType") SELECT "design", "id", "productType" FROM "Customization";
+DROP TABLE "Customization";
+ALTER TABLE "new_Customization" RENAME TO "Customization";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,9 +32,11 @@ model Session {
 }
 
 model Customization {
-  id          String @id @default(cuid())
+  id          String   @id @default(cuid())
+  userId      String?
   productType String
-  color       String
-  design      String
+  design      Json
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 


### PR DESCRIPTION
## Summary
- define `Customization` model with user and timestamps
- create migration for new schema

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683fceef697883309c43ff319b673f35